### PR TITLE
[npcs/sphere_monsters.scp]: Removed chardef 023d (the new/broken AOS …

### DIFF
--- a/npcs/sphere_monsters.scp
+++ b/npcs/sphere_monsters.scp
@@ -7,7 +7,7 @@
 // Menasoft & Partners.  All donations and contributions
 // become the property of Menasoft & Partners.
 //****************************************************************************
-// FILE LAST UPDATED: Wednesday, May 24, 2017
+// FILE LAST UPDATED: Wednesday, Jul 5, 2017
 //
 VERSION=0.56d
 
@@ -2612,7 +2612,6 @@ ON=@Create
    RESFIRE={20 40}
    RESPOISON={5 10}
    ITEMNEWBIE=i_light_source
-   ATTR=attr_magic|attr_newbie
 ON=@NPCRestock
    ITEM=loot_wisp
 
@@ -7518,52 +7517,39 @@ ON=@GetHit
    ENDIF
 
 [CHARDEF 0a4]
-//FIXME: No Stratics entry...looks like a purple air elemental
-DEFNAME=c_elemental_swamp
-NAME=swamp elemental
-ICON=i_pet_elem_blood
-SOUND=snd_elementl_watrel1
-CAN=MT_WALK|MT_SWIM|MT_NONHUM
-DAM=18,36
-ARMOR=45
-DESIRES=r_swamp,t_coin,t_gold,t_gem,t_wand,t_potion,t_scroll,t_reagent
-AVERSIONS=t_trap,r_civilization
-//FOODTYPE=
-//MAXFOOD=
-//RESOURCES=
-BLOODCOLOR=colors_green
-TAG.Barding.Diff=130.1
-DamPoison=50
-TAG.HitPoison=4	//Deadly
-TAG.SlayerGroup=ELEMENTAL
-CATEGORY=Monsters
-SUBSECTION=Elementals
-DESCRIPTION=Swamp Elemental
+DEFNAME=c_energy_vortex
+NAME=energy vortex
+ICON=i_fx_blade_spirit_1
+SOUND=snd_elementl_airelem1
+CAN=MT_WALK|MT_RUN|MT_NONHUM
+DAM=14,17
+ARMOR=40
+BLOODCOLOR=-1
+MOVERATE=150
+FollowerSlots=2
+DamEnergy=100
+CATEGORY=Spells
+SUBSECTION=Magery
+DESCRIPTION=Energy Vortex
 ON=@Create
-   NPC=brain_monster
-   FAME={2500 2999}
-   KARMA={-2500 -2999}
-   STR={350 400}
-   MAXHITS={350 400}
-   DEX={115 125}
-   MAXSTAM={115 125}
-   INT={126 150}
-   MAXMANA={126 150}
-   MAXMANA={226 350}
-   EVALUATINGINTEL={65.0 70.0}
-   MAGERY={65.0 70.0}
-   MAGICRESISTANCE={60.0 75.0}
-   MEDITATION={10.0 50.0}
-   POISONING={100.0 110.0}
-   TACTICS={60.0 70.0}
-   WRESTLING={60.0 70.0}
-   MODAR={0 10}
+   NPC=brain_berserk
+   FAME=0
+   KARMA=0
+   STR=200
+   DEX=200
+   INT=100
+   MAXHITS=140
+   MAXSTAM=250
+   MAXMANA=0
+   MAGICRESISTANCE=100.0
+   TACTICS=100.0
+   WRESTLING=120.0
+   RESPHYSICAL={60 70}
+   RESFIRE={40 50}
    RESCOLD={40 50}
-   RESENERGY={10 20}
-   RESFIRE={20 30}
-   RESPOISON={50 60}
-ON=@NPCRestock
-   ITEM=loot_elem_swamp
+   RESPOISON={40 50}
+   RESENERGY={90 100}
+   ITEMNEWBIE=i_light_source
 
 [CHARDEF 0a5]
 DEFNAME=c_wisp_dark
@@ -7607,7 +7593,6 @@ ON=@Create
    RESFIRE={10 20}
    RESPOISON={10 20}
    ITEMNEWBIE=i_light_source
-   ATTR=attr_magic|attr_newbie
 ON=@NPCRestock
    ITEM=loot_wisp_dark
 
@@ -14905,62 +14890,20 @@ ON=@NPCRestock
    ITEM=i_boura_pelt,{1 3},R5
 
 
-[CHARDEF 023d]
-//"Not visible with some clients, if so, set BODY=c_elemental_air
-// in the ON=@Create trigger."
-DEFNAME=c_vortex
-NAME=energy vortex
-ICON=i_fx_blade_spirit_1
-SOUND=snd_special_spelleffect1
-CAN=MT_WALK|MT_FLY|MT_NONHUM
-DAM=33,40//FIXME: Might be too strong...
-ARMOR=60
-//FOODTYPE=
-//MAXFOOD=
-//RESOURCES=
-BLOODCOLOR=-1
-MOVERATE=150
-TAG.Barding.Diff=75.3
-FollowerSlots=2
-DamEnergy=100
-CATEGORY=Spells
-SUBSECTION=Magery
-DESCRIPTION=Energy Vortex
-ON=@Create
-   NPC=brain_berserk
-   FAME={1500 1999}
-   KARMA={-1500 -1999}
-   STR={195 205}
-   MAXHITS={135 145}
-   DEX={195 205}//FIXME: Might be too fast...
-   MAXSTAM={195 205}
-   INT={95 105}
-   MAXMANA={95 105}
-   MAGICRESISTANCE={95.0 105.0}
-   TACTICS={95.0 105.0}
-   WRESTLING={115.0 125.0}
-   RESCOLD={40 50}
-   RESENERGY={90 100}
-   RESFIRE={40 50}
-   RESPOISON={40 50}
-   MODAR={0 10}
-   ITEMNEWBIE=i_light_source
-   ATTR=attr_magic|attr_newbie
+//[CHARDEF 023d]
+//OSI created this chardef to use it as an "new" Energy Vortex but it was never used.
+//It doesn't even have proper animations.
 
 [CHARDEF 023e]
 DEFNAME=c_blade_spirit
 NAME=blade spirit
 ICON=i_fx_blade_spirit_1
 SOUND=snd_weapons_sword1
-CAN=MT_WALK|MT_FLY|MT_NONHUM
-DAM=20,32//FIXME: Might be too strong...
-ARMOR=30
-//FOODTYPE=
-//MAXFOOD=
-//RESOURCES=
+CAN=MT_WALK|MT_RUN|MT_NONHUM
+DAM=10,14
+ARMOR=40
 BLOODCOLOR=-1
 MOVERATE=150
-TAG.Barding.Diff=74.5
 FollowerSlots=2
 DamPoison=20
 DamEnergy=20
@@ -14971,21 +14914,20 @@ ON=@Create
    NPC=brain_berserk
    FAME=0
    KARMA=0
-   STR={145 155}
-   MAXHITS={145 155}
-   DEX={145 155}//FIXME: Might be too fast...
-   MAXSTAM={245 255}
-   INT={95 105}
-   MAXMANA={95 105}
-   MAGICRESISTANCE={65.0 75.0}
-   POISONING={15.0 25.0}
-   TACTICS={95.0 105.0}
-   WRESTLING={85.0 95.0}
-   MODAR={0 10}
-   RESCOLD={30 40}
-   RESENERGY={20 30}
+   STR=150
+   DEX=150
+   INT=100
+   MAXHITS=160
+   MAXSTAM=250
+   MAXMANA=0
+   MAGICRESISTANCE=70.0
+   TACTICS=90.0
+   WRESTLING=90.0
+   RESPHYSICAL={30 40}
    RESFIRE={40 50}
+   RESCOLD={30 40}
    RESPOISON=100
+   RESENERGY={20 30}
 
 
 [CHARDEF 025d]

--- a/sphere_defs.scp
+++ b/sphere_defs.scp
@@ -7,7 +7,7 @@
 // Menasoft & Partners.  All donations and contributions
 // become the property of Menasoft & Partners.
 //****************************************************************************
-// FILE LAST UPDATED: Wednesday, May 24, 2017
+// FILE LAST UPDATED: Wednesday, Jul 5, 2017
 //
 VERSION=0.56d
 
@@ -1942,7 +1942,7 @@ height_0a0 18 //DEFNAME=c_elemental_unknown_red
 height_0a1 18 //DEFNAME=c_elemental_ice
 height_0a2 18 //DEFNAME=c_elemental_poison
 height_0a3 18 //DEFNAME=c_elemental_snow
-height_0a4 16 //DEFNAME=c_elemental_swamp
+height_0a4 16 //DEFNAME=c_energy_vortex
 height_0a5 15 //DEFNAME=c_wisp_dark
 height_0a6 18 //DEFNAME=c_elemental_ore_gold
 height_0a7 9  //DEFNAME=c_bear_brown
@@ -2086,13 +2086,12 @@ height_0191 16 //DEFNAME=c_woman
 height_0192 16 //DEFNAME=c_ghost_man
 height_0193 16 //DEFNAME=c_ghost_woman
 
-height_01a4 8 //DEFNAME=c_child_mb
-height_01a5 8 //DEFNAME=c_child_md
-height_01a6 8 //DEFNAME=c_child_fb
-height_01a7 8 //DEFNAME=c_child_fd
-height_01a8 2 //DEFNAME=c_man_invisible
+height_01a4 8  //DEFNAME=c_child_mb
+height_01a5 8  //DEFNAME=c_child_md
+height_01a6 8  //DEFNAME=c_child_fb
+height_01a7 8  //DEFNAME=c_child_fd
+height_01a8 2  //DEFNAME=c_man_invisible
 
-height_023d 18 //DEFNAME=c_vortex
 height_023e 16 //DEFNAME=c_blade_spirit
 
 height_025d 16 //DEFNAME=c_elf_male

--- a/sphere_spawns.scp
+++ b/sphere_spawns.scp
@@ -7,7 +7,7 @@
 // Menasoft & Partners.  All donations and contributions
 // become the property of Menasoft & Partners.
 //****************************************************************************
-// FILE LAST UPDATED: Monday, May 1, 2017
+// FILE LAST UPDATED: Wednesday, Jul 5, 2017
 //
 VERSION=0.56d
 
@@ -749,9 +749,8 @@ ID=c_kaze_kemono             7
 ID=c_crystal_elemental       7
 ID=c_efreet                  6
 ID=c_elemental_acid          5
-ID=c_elemental_swamp         4
-ID=c_elemental_snow          3
-ID=c_elemental_poison        2
+ID=c_elemental_snow          4
+ID=c_elemental_poison        3
 ID=c_elemental_lava          2
 ID=c_elemental_blood         1
 
@@ -1089,7 +1088,6 @@ CATEGORY=Spawn Groups
 SUBSECTION=Monsters
 DESCRIPTION=Void Monsters
 ID=c_wanderer_void         1
-//ID=c_vortex                1
 
 [SPAWN spawn_Worms]
 CATEGORY=Spawn Groups
@@ -1245,7 +1243,6 @@ ID=c_quagmire                9
 ID=c_swamp_dragon
 ID=c_kappa                   6
 ID=c_slith_toxic             5
-ID=c_elemental_swamp         5
 ID=c_steed_dark
 ID=c_plague_beast            4
 ID=c_elemental_poison        3
@@ -1558,7 +1555,6 @@ ID=c_skeletal_mount
 ID=c_minotaur
 ID=c_wanderer_void
 ID=c_patchwork_skeleton
-//ID=c_vortex
 ID=c_gargoyle
 ID=c_ogre
 ID=c_ettin
@@ -1648,7 +1644,6 @@ ID=c_demon_ice
 ID=c_gargoyle_stone
 ID=c_succubus
 ID=c_mummy
-ID=c_elemental_swamp
 ID=c_steed_fire
 ID=c_meer_mage
 ID=c_demon_moloch
@@ -1790,7 +1785,6 @@ ID=c_slith
 ID=c_skeletal_mount
 ID=c_minotaur
 ID=c_patchwork_skeleton
-//ID=c_vortex
 ID=c_ophidian_justicar
 ID=c_corpser
 ID=c_ettin_w_hammer
@@ -1846,7 +1840,6 @@ ID=c_cyclops
 ID=c_slith_toxic
 ID=c_solen_warrior
 ID=c_goblin_gray
-ID=c_elemental_swamp
 ID=c_mummy
 ID=c_demon_moloch
 ID=c_serpent_lava
@@ -2042,7 +2035,6 @@ ID=c_demon_arcane
 ID=c_skeletal_mount
 ID=c_wanderer_void
 ID=c_patchwork_skeleton
-//ID=c_vortex
 ID=c_corpser
 ID=c_hellcat_pred
 ID=c_giant_beetle
@@ -2092,7 +2084,6 @@ ID=c_gargoyle_undead
 ID=c_demon_ice
 ID=c_gargoyle_stone
 ID=c_gargoyle_fire
-ID=c_elemental_swamp
 ID=c_demon_moloch
 ID=c_serpent_lava
 ID=c_warhorse_dread

--- a/sphere_template_loot.scp
+++ b/sphere_template_loot.scp
@@ -1,5 +1,5 @@
 //****************************************************************************
-// SPHERE by : Menasoft ©1997-2007
+// SPHERE by : Menasoft ©1997-2017
 // www.sphereserver.net
 // All SPHERE script files and formats are copyright Menasoft & Partners.
 // This file may be freely edited for personal use, but may not be distributed
@@ -7,9 +7,9 @@
 // Menasoft & Partners.  All donations and contributions
 // become the property of Menasoft & Partners.
 //****************************************************************************
-// FILE LAST UPDATED: Sunday, October 6, 2013
+// FILE LAST UPDATED: Wednesday, Jul 5, 2017
 //
-VERSION=0.56c
+VERSION=0.56d
 
 
 /////////////////////////
@@ -1236,19 +1236,6 @@ SUBSECTION=Monster Loot Templates
 DESCRIPTION=Elemental (crystal)
 ITEM=i_gold,{400 500}
 ITEM=random_jewel,{3 5}
-
-[TEMPLATE loot_elem_swamp]
-CATEGORY=Item Templates
-SUBSECTION=Monster Loot Templates
-DESCRIPTION=Elemental (swamp)
-ITEM=i_gold,{400 500}
-ITEM=random_jewel,{1 2}
-ITEM=random_potion,R2
-ITEM=random_scroll,{1 2}
-CONTAINER=i_backpack
-ITEM=i_gold,{75 100}
-ITEM=random_scroll,{1 3},R3
-//ITEM=i_map_treasure,R40
 
 [TEMPLATE loot_elem_sand_vortex]
 CATEGORY=Item Templates


### PR DESCRIPTION
…Energy Vortex) and renamed old chardef 0a4 'c_elemental_swamp' to 'c_energy_vortex'. Also updated Blade Spirit and Energy Vortex stats

[sphere_spawns.scp]: Removed 'c_elemental_swamp' from spawn lists
[sphere_template_loot.scp]: Removed template 'loot_elem_swamp'